### PR TITLE
Update Metric Names

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,9 +477,9 @@ The service exposes metrics about its operation:
 
 | Metric | Type | Description | Labels |
 |--------|------|-------------|--------|
-| `otel_forwarder_requests_total` | Counter | Total forwarded requests | `signal.type`, `signal.tenant`, `signal.status` |
-| `otel_forwarder_request_duration_seconds` | Histogram | Request latency | `signal.type`, `signal.tenant` |
-| `otel_forwarder_response_code_total` | Counter | Response codes | `signal.type`, `signal.tenant`, `signal.response` |
+| `otel_lgtm_proxy_requests_total` | Counter | Total forwarded requests | `signal.type`, `signal.tenant`, `signal.status` |
+| `otel_lgtm_proxy_request_duration_seconds` | Histogram | Request latency | `signal.type`, `signal.tenant` |
+| `otel_lgtm_proxy_response_code_total` | Counter | Response codes | `signal.type`, `signal.tenant`, `signal.response` |
 
 ## Development
 

--- a/internal/logs/logs.go
+++ b/internal/logs/logs.go
@@ -44,29 +44,29 @@ type Client interface {
 // New creates a new Logs instance.
 func New(config *config.Config, client Client, logger log.Logger, meter metric.Meter, tracer trace.Tracer) (*Logs, error) {
 
-	otelForwarderCounter, err := meter.Int64Counter(
-		"otel_forwarder_requests_total",
-		metric.WithDescription("Total number of otel forwarder requests"),
+	otelLgtmProxyCounter, err := meter.Int64Counter(
+		"otel_lgtm_proxy_requests_total",
+		metric.WithDescription("Total number of otel lgtm proxy requests"),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create otel forwarder counter: %w", err)
+		return nil, fmt.Errorf("failed to create otel lgtm proxy counter: %w", err)
 	}
 
-	otelForwarderLatency, err := meter.Int64Histogram(
-		"otel_forwarder_request_duration_seconds",
-		metric.WithDescription("Latency of otel forwarder requests"),
+	otelLgtmProxyLatency, err := meter.Int64Histogram(
+		"otel_lgtm_proxy_request_duration_seconds",
+		metric.WithDescription("Latency of otel lgtm proxy requests"),
 		metric.WithUnit("ms"),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create otel forwarder latency histogram: %w", err)
+		return nil, fmt.Errorf("failed to create otel lgtm proxy latency histogram: %w", err)
 	}
 
-	otelForwarderResponseCode, err := meter.Int64Counter(
-		"otel_forwarder_response_code_total",
-		metric.WithDescription("Status code of otel forwarder responses"),
+	otelLgtmProxyResponseCode, err := meter.Int64Counter(
+		"otel_lgtm_proxy_response_code_total",
+		metric.WithDescription("Status code of otel lgtm proxy responses"),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create otel_forwarder_response_code_total counter: %w", err)
+		return nil, fmt.Errorf("failed to create otel_lgtm_proxy_response_code_total counter: %w", err)
 	}
 
 	if certutil.TLSEnabled(&config.Logs.TLS) {
@@ -86,9 +86,9 @@ func New(config *config.Config, client Client, logger log.Logger, meter metric.M
 		logger:                    logger,
 		meter:                     meter,
 		tracer:                    tracer,
-		otelForwarderCounter:      otelForwarderCounter,
-		otelForwarderLatency:      otelForwarderLatency,
-		otelForwarderResponseCode: otelForwarderResponseCode,
+		otelForwarderCounter:      otelLgtmProxyCounter,
+		otelForwarderLatency:      otelLgtmProxyLatency,
+		otelForwarderResponseCode: otelLgtmProxyResponseCode,
 	}, nil
 }
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -44,29 +44,29 @@ type Client interface {
 // New creates a new Metrics instance.
 func New(config *config.Config, client Client, logger log.Logger, meter metric.Meter, traces trace.Tracer) (*Metrics, error) {
 
-	otelForwarderCounter, err := meter.Int64Counter(
-		"otel_forwarder_requests_total",
-		metric.WithDescription("Total number of otel forwarder requests"),
+	otelLgtmProxyCounter, err := meter.Int64Counter(
+		"otel_lgtm_proxy_requests_total",
+		metric.WithDescription("Total number of otel lgtm proxy requests"),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create otel forwarder counter: %w", err)
+		return nil, fmt.Errorf("failed to create otel lgtm proxy counter: %w", err)
 	}
 
-	otelForwarderLatency, err := meter.Int64Histogram(
-		"otel_forwarder_request_duration_seconds",
-		metric.WithDescription("Latency of otel forwarder requests"),
+	otelLgtmProxyLatency, err := meter.Int64Histogram(
+		"otel_lgtm_proxy_request_duration_seconds",
+		metric.WithDescription("Latency of otel lgtm proxy requests"),
 		metric.WithUnit("ms"),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create otel forwarder latency histogram: %w", err)
+		return nil, fmt.Errorf("failed to create otel lgtm proxy latency histogram: %w", err)
 	}
 
-	otelForwarderResponseCode, err := meter.Int64Counter(
-		"otel_forwarder_response_code_total",
-		metric.WithDescription("Status code of otel forwarder responses"),
+	otelLgtmProxyResponseCode, err := meter.Int64Counter(
+		"otel_lgtm_proxy_response_code_total",
+		metric.WithDescription("Status code of otel lgtm proxy responses"),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create otel_forwarder_response_code_total counter: %w", err)
+		return nil, fmt.Errorf("failed to create otel_lgtm_proxy_response_code_total counter: %w", err)
 	}
 
 	if certutil.TLSEnabled(&config.Metrics.TLS) {
@@ -86,9 +86,9 @@ func New(config *config.Config, client Client, logger log.Logger, meter metric.M
 		logger:                    logger,
 		meter:                     meter,
 		tracer:                    traces,
-		otelForwarderCounter:      otelForwarderCounter,
-		otelForwarderLatency:      otelForwarderLatency,
-		otelForwarderResponseCode: otelForwarderResponseCode,
+		otelForwarderCounter:      otelLgtmProxyCounter,
+		otelForwarderLatency:      otelLgtmProxyLatency,
+		otelForwarderResponseCode: otelLgtmProxyResponseCode,
 	}, nil
 }
 

--- a/internal/traces/traces.go
+++ b/internal/traces/traces.go
@@ -44,29 +44,29 @@ type Client interface {
 // New creates a new Traces instance.
 func New(config *config.Config, client Client, logger log.Logger, meter metric.Meter, tracer trace.Tracer) (*Traces, error) {
 
-	otelForwarderCounter, err := meter.Int64Counter(
-		"otel_forwarder_requests_total",
-		metric.WithDescription("Total number of otel forwarder requests"),
+	otelLgtmProxyCounter, err := meter.Int64Counter(
+		"otel_lgtm_proxy_requests_total",
+		metric.WithDescription("Total number of otel lgtm proxy requests"),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create otel forwarder counter: %w", err)
+		return nil, fmt.Errorf("failed to create otel lgtm proxy counter: %w", err)
 	}
 
-	otelForwarderLatency, err := meter.Int64Histogram(
-		"otel_forwarder_request_duration_seconds",
-		metric.WithDescription("Latency of otel forwarder requests"),
+	otelLgtmProxyLatency, err := meter.Int64Histogram(
+		"otel_lgtm_proxy_request_duration_seconds",
+		metric.WithDescription("Latency of otel lgtm proxy requests"),
 		metric.WithUnit("ms"),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create otel forwarder latency histogram: %w", err)
+		return nil, fmt.Errorf("failed to create otel lgtm proxy latency histogram: %w", err)
 	}
 
-	otelForwarderResponseCode, err := meter.Int64Counter(
-		"otel_forwarder_response_code_total",
-		metric.WithDescription("Status code of otel forwarder responses"),
+	otelLgtmProxyResponseCode, err := meter.Int64Counter(
+		"otel_lgtm_proxy_response_code_total",
+		metric.WithDescription("Status code of otel lgtm proxy responses"),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create otel_forwarder_response_code_total counter: %w", err)
+		return nil, fmt.Errorf("failed to create otel_lgtm_proxy_response_code_total counter: %w", err)
 	}
 
 	if certutil.TLSEnabled(&config.Traces.TLS) {
@@ -87,9 +87,9 @@ func New(config *config.Config, client Client, logger log.Logger, meter metric.M
 		logger:                    logger,
 		meter:                     meter,
 		tracer:                    tracer,
-		otelForwarderCounter:      otelForwarderCounter,
-		otelForwarderLatency:      otelForwarderLatency,
-		otelForwarderResponseCode: otelForwarderResponseCode,
+		otelForwarderCounter:      otelLgtmProxyCounter,
+		otelForwarderLatency:      otelLgtmProxyLatency,
+		otelForwarderResponseCode: otelLgtmProxyResponseCode,
 	}, nil
 }
 


### PR DESCRIPTION
The metrics names still had the old project naming `otel_forwarder_*`. This change updates these to be `otel_lgtm_proxy_*`.