### PR TITLE
Records Metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,7 +477,8 @@ The service exposes metrics about its operation:
 
 | Metric | Type | Description | Labels |
 |--------|------|-------------|--------|
-| `otel_lgtm_proxy_requests_total` | Counter | Total forwarded requests | `signal.type`, `signal.tenant`, `signal.status` |
+| `otel_lgtm_proxy_requests_total` | Counter | Total number of proxy requests | `signal.type`, `signal.tenant`, `signal.status` |
+| `otel_lgtm_proxy_records_total` | Counter | Total number of records processed | `signal.type`, `signal.tenant`, `signal.status` |
 | `otel_lgtm_proxy_request_duration_seconds` | Histogram | Request latency | `signal.type`, `signal.tenant` |
 | `otel_lgtm_proxy_response_code_total` | Counter | Response codes | `signal.type`, `signal.tenant`, `signal.response` |
 


### PR DESCRIPTION
We  are introducing a new metric which will be the number of records that have been processed through the proxy. This was previously the requests counter metric but this is misleading, so now the requests counter metric is a count of the number of requests and the new records metric is a count of the number of the records that the proxy had processed. So this should be a lot more intuitive.