### PR TITLE
Reduce Image Size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+# Git and CI/CD
+.git
+.github
+.gitignore
+
+# Documentation
+README.md
+CONTRIBUTING.md
+LICENSE
+
+# Development tools
+.golangci.yml
+
+# Test files and infrastructure
+test/
+**/*_test.go
+
+# Docker files (not needed in build)
+docker-compose.yml
+Dockerfile
+
+# Compiled binaries from local builds
+main

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,13 @@ WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 
-COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o otel-lgtm-proxy ./cmd/main.go
+COPY cmd/ ./cmd/
+COPY internal/ ./internal/
+RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags="-s -w" -trimpath -o otel-lgtm-proxy ./cmd/main.go
 
 FROM alpine:latest
 RUN apk --no-cache add ca-certificates
-WORKDIR /root/
+WORKDIR /app
 
 COPY --from=builder /app/otel-lgtm-proxy .
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,8 +119,8 @@ services:
   # Test Client using bash scripts - sends all telemetry types
   test-client:
     build:
-      context: .
-      dockerfile: test/Dockerfile
+      context: ./test
+      dockerfile: Dockerfile
     environment:
       - OTEL_COLLECTOR_ENDPOINT=http://otel-collector:4318
       - TENANTS=tenant-a,tenant-b

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache bash curl openssl
 WORKDIR /app
 
 # Copy the test scripts
-COPY test/send-*.sh ./
+COPY send-*.sh ./
 RUN chmod +x send-*.sh
 
 # Default command


### PR DESCRIPTION
By setting some build flags when we build the go binary we can reduce the size of it, and therefore reduce the size of the image.

Before this change the image was 48Mb, after the change the image was about 32Mb, so about a 33% reduction.