### PR TITLE
Generic Logger/Otel

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -31,7 +31,7 @@ func main() {
 	}
 
 	// Initialize OpenTelemetry provider
-	provider, err := otel.NewProvider(ctx, *cfg)
+	provider, err := otel.NewProvider(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -55,21 +55,21 @@ func main() {
 	// Create HTTP clients for logs
 	logsClient, err := newClient(ctx, loggingProvider, &cfg.Logs)
 	if err != nil {
-		logger.Error(ctx, loggingProvider, "failed to create logs client", logger.Err(err))
+		logger.Error(ctx, loggingProvider, "failed to create logs client", attribute.String(otel.ErrorAttrKey, err.Error()))
 		os.Exit(1)
 	}
 
 	// Create HTTP clients for metrics
 	metricsClient, err := newClient(ctx, loggingProvider, &cfg.Metrics)
 	if err != nil {
-		logger.Error(ctx, loggingProvider, "failed to create metrics client", logger.Err(err))
+		logger.Error(ctx, loggingProvider, "failed to create metrics client", attribute.String(otel.ErrorAttrKey, err.Error()))
 		os.Exit(1)
 	}
 
 	// Create HTTP clients for traces
 	tracesClient, err := newClient(ctx, loggingProvider, &cfg.Traces)
 	if err != nil {
-		logger.Error(ctx, loggingProvider, "failed to create traces client", logger.Err(err))
+		logger.Error(ctx, loggingProvider, "failed to create traces client", attribute.String(otel.ErrorAttrKey, err.Error()))
 		os.Exit(1)
 	}
 
@@ -110,18 +110,29 @@ func main() {
 		MinVersion: tls.VersionTLS13,
 	}
 
+	// Add attributes for TLS configuration
+	tlsEnabled := cert.TLSEnabled(&cfg.HTTP.TLS)
+	httpAttributes := []attribute.KeyValue{
+		attribute.String(otel.HTTPAddressAttrKey, cfg.HTTP.Address),
+		attribute.Bool(otel.HTTPTLSEnabledAttrKey, tlsEnabled),
+	}
+
 	// Load TLS certificates
-	if cert.TLSEnabled(&cfg.HTTP.TLS) {
+	if tlsEnabled {
 		certPair, err := tls.LoadX509KeyPair(cfg.HTTP.TLS.CertFile, cfg.HTTP.TLS.KeyFile)
 		if err != nil {
-			logger.Error(ctx, loggingProvider, "unable to read certificate or key file", logger.Err(err))
+			logger.Error(ctx, loggingProvider, "unable to read certificate or key file",
+				append(httpAttributes, attribute.String(otel.ErrorAttrKey, err.Error()))...,
+			)
 			os.Exit(1)
 		}
 
 		caPool := x509.NewCertPool()
 		caCert, err := os.ReadFile(cfg.HTTP.TLS.CAFile)
 		if err != nil {
-			logger.Error(ctx, loggingProvider, "unable to read CA file", logger.Err(err))
+			logger.Error(ctx, loggingProvider, "unable to read CA file",
+				append(httpAttributes, attribute.String(otel.ErrorAttrKey, err.Error()))...,
+			)
 			os.Exit(1)
 		}
 
@@ -136,11 +147,7 @@ func main() {
 	server := h.NewServer(tlsConfig)
 
 	go func() {
-		tlsEnabled := cert.TLSEnabled(&cfg.HTTP.TLS)
-		logger.Info(ctx, loggingProvider, "starting server",
-			logger.String(otel.HTTPAddressAttrKey, cfg.HTTP.Address),
-			logger.Bool(otel.HTTPTLSEnabledAttrKey, tlsEnabled),
-		)
+		logger.Info(ctx, loggingProvider, "starting server", httpAttributes...)
 
 		if tlsEnabled {
 			err = server.ListenAndServeTLS("", "")
@@ -149,10 +156,7 @@ func main() {
 		}
 
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {
-			logger.Error(ctx, loggingProvider, err.Error(),
-				logger.String(otel.HTTPAddressAttrKey, cfg.HTTP.Address),
-				logger.Bool(otel.HTTPTLSEnabledAttrKey, tlsEnabled),
-			)
+			logger.Error(ctx, loggingProvider, err.Error(), httpAttributes...)
 			os.Exit(1)
 		}
 	}()
@@ -166,9 +170,7 @@ func main() {
 	defer cancel()
 	if err := server.Shutdown(shutdownCtx); err != nil {
 		logger.Error(ctx, loggingProvider, "http close error",
-			logger.Err(err),
-			logger.String(otel.HTTPAddressAttrKey, cfg.HTTP.Address),
-			logger.Bool(otel.HTTPTLSEnabledAttrKey, cert.TLSEnabled(&cfg.HTTP.TLS)),
+			append(httpAttributes, attribute.String(otel.ErrorAttrKey, err.Error()))...,
 		)
 		os.Exit(1)
 	}
@@ -177,32 +179,24 @@ func main() {
 // newClient creates a new HTTP client with the specified timeout and TLS configuration.
 func newClient(ctx context.Context, loggingProvider log.Logger, endpoint *config.Endpoint) (*http.Client, error) {
 	clientAttributes := []attribute.KeyValue{
-		logger.String(otel.HTTPClientURLAttrKey, endpoint.Address),
-		logger.Int64(otel.HTTPClientTimeoutAttrKey, int64(endpoint.Timeout.Seconds())),
-		logger.Bool(otel.HTTPClientTLSEnabledAttrKey, cert.TLSEnabled(&endpoint.TLS)),
+		attribute.String(otel.HTTPClientURLAttrKey, endpoint.Address),
+		attribute.Int64(otel.HTTPClientTimeoutAttrKey, int64(endpoint.Timeout.Seconds())),
+		attribute.Bool(otel.HTTPClientTLSEnabledAttrKey, cert.TLSEnabled(&endpoint.TLS)),
 	}
 
 	c := &http.Client{Timeout: endpoint.Timeout}
 	if cert.TLSEnabled(&endpoint.TLS) {
 		tlsConfig, err := cert.CreateTLSConfig(endpoint)
 		if err != nil {
-			logger.Error(
-				ctx,
-				loggingProvider,
-				"failed to create TLS config",
-				append(clientAttributes, logger.Err(err))...,
+			logger.Error(ctx, loggingProvider, "failed to create TLS config",
+				append(clientAttributes, attribute.String(otel.ErrorAttrKey, err.Error()))...,
 			)
 			return nil, err
 		}
 		c.Transport = &http.Transport{TLSClientConfig: tlsConfig}
 	}
 
-	logger.Info(
-		ctx,
-		loggingProvider,
-		"created HTTP client",
-		clientAttributes...,
-	)
+	logger.Info(ctx, loggingProvider, "created HTTP client", clientAttributes...)
 
 	return c, nil
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,8 @@ services:
       - OLP_LOGS_ADDRESS=http://loki:3100/otlp/v1/logs
       - OLP_METRICS_ADDRESS=http://mimir:8080/otlp/v1/metrics
       - OLP_TRACES_ADDRESS=http://tempo:3201/v1/traces
+      - OTEL_SERVICE_NAME=otel-lgtm-proxy
+      - OTEL_SERVICE_VERSION=1.0.0
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
       - OTEL_EXPORTER_OTLP_INSECURE=true
       - OTEL_METRICS_EXPORTER=otlp

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -62,33 +62,3 @@ func Error(ctx context.Context, logger log.Logger, msg string, attrs ...attribut
 	}
 	logger.Emit(ctx, record)
 }
-
-// String creates a string-valued log attribute.
-func String(key, value string) attribute.KeyValue {
-	return attribute.String(key, value)
-}
-
-// Int creates an integer-valued log attribute.
-func Int(key string, value int) attribute.KeyValue {
-	return attribute.Int(key, value)
-}
-
-// Int64 creates an int64-valued log attribute.
-func Int64(key string, value int64) attribute.KeyValue {
-	return attribute.Int64(key, value)
-}
-
-// Float64 creates a float64-valued log attribute.
-func Float64(key string, value float64) attribute.KeyValue {
-	return attribute.Float64(key, value)
-}
-
-// Bool creates a boolean-valued log attribute.
-func Bool(key string, value bool) attribute.KeyValue {
-	return attribute.Bool(key, value)
-}
-
-// Err creates an error log attribute with key "error".
-func Err(err error) attribute.KeyValue {
-	return attribute.String("error", err.Error())
-}

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -153,45 +153,6 @@ func TestLogWithAttributes(t *testing.T) {
 	}
 }
 
-func TestHelperFunctions(t *testing.T) {
-	t.Run("String", func(t *testing.T) {
-		kv := String("key", "value")
-		assert.Equal(t, attribute.Key("key"), kv.Key)
-		assert.Equal(t, attribute.StringValue("value"), kv.Value)
-	})
-
-	t.Run("Int", func(t *testing.T) {
-		kv := Int("key", 42)
-		assert.Equal(t, attribute.Key("key"), kv.Key)
-		assert.Equal(t, attribute.Int64Value(42), kv.Value)
-	})
-
-	t.Run("Int64", func(t *testing.T) {
-		kv := Int64("key", 9223372036854775807)
-		assert.Equal(t, attribute.Key("key"), kv.Key)
-		assert.Equal(t, attribute.Int64Value(9223372036854775807), kv.Value)
-	})
-
-	t.Run("Float64", func(t *testing.T) {
-		kv := Float64("key", 3.14)
-		assert.Equal(t, attribute.Key("key"), kv.Key)
-		assert.Equal(t, attribute.Float64Value(3.14), kv.Value)
-	})
-
-	t.Run("Bool", func(t *testing.T) {
-		kv := Bool("key", true)
-		assert.Equal(t, attribute.Key("key"), kv.Key)
-		assert.Equal(t, attribute.BoolValue(true), kv.Value)
-	})
-
-	t.Run("Err", func(t *testing.T) {
-		testErr := errors.New("test error")
-		kv := Err(testErr)
-		assert.Equal(t, attribute.Key("error"), kv.Key)
-		assert.Equal(t, attribute.StringValue("test error"), kv.Value)
-	})
-}
-
 func TestLogOutput(t *testing.T) {
 	logger, buf, err := createTestLogger()
 	assert.NoError(t, err)

--- a/internal/otel/otel.go
+++ b/internal/otel/otel.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/matt-gp/otel-lgtm-proxy/internal/config"
 	"go.opentelemetry.io/contrib/processors/minsev"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc"
@@ -82,7 +81,7 @@ type Provider struct {
 
 // NewProvider creates a new OpenTelemetry provider using environment variables
 // This function relies heavily on OpenTelemetry's built-in environment variable support
-func NewProvider(ctx context.Context, config config.Config) (*Provider, error) {
+func NewProvider(ctx context.Context) (*Provider, error) {
 	// Check if OpenTelemetry is disabled
 	if os.Getenv("OTEL_SDK_DISABLED") == "true" {
 		return &Provider{}, nil
@@ -92,8 +91,8 @@ func NewProvider(ctx context.Context, config config.Config) (*Provider, error) {
 	// merge this with OTEL_RESOURCE_ATTRIBUTES from environment
 	res, err := resource.New(ctx,
 		resource.WithAttributes(
-			semconv.ServiceNameKey.String(config.Service.Name),
-			semconv.ServiceVersionKey.String(config.Service.Version),
+			semconv.ServiceNameKey.String(os.Getenv("OTEL_SERVICE_NAME")),
+			semconv.ServiceVersionKey.String(os.Getenv("OTEL_SERVICE_VERSION")),
 		),
 		resource.WithFromEnv(),   // Automatically parse OTEL_RESOURCE_ATTRIBUTES
 		resource.WithProcess(),   // Add process information

--- a/internal/otel/otel_test.go
+++ b/internal/otel/otel_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/matt-gp/otel-lgtm-proxy/internal/config"
 	"go.opentelemetry.io/contrib/processors/minsev"
 )
 
@@ -123,6 +122,9 @@ func TestNewProvider(t *testing.T) {
 			// Clear all OTEL env vars first
 			clearOtelEnvVars()
 
+			t.Setenv("OTEL_SERVICE_NAME", "test-service")
+			t.Setenv("OTEL_SERVICE_VERSION", "0.0.1")
+
 			// Set test-specific env vars
 			for key, value := range tt.envVars {
 				err := os.Setenv(key, value)
@@ -136,12 +138,7 @@ func TestNewProvider(t *testing.T) {
 				}()
 			}
 
-			provider, err := NewProvider(context.Background(), config.Config{
-				Service: config.Service{
-					Name:    "test-service",
-					Version: "1.0.0",
-				},
-			})
+			provider, err := NewProvider(context.Background())
 			if err != nil {
 				t.Fatalf("Failed to setup provider: %v", err)
 			}
@@ -248,12 +245,8 @@ func TestShutdown(t *testing.T) {
 				}()
 			}
 
-			provider, err := NewProvider(context.Background(), config.Config{
-				Service: config.Service{
-					Name:    "test-service",
-					Version: "1.0.0",
-				},
-			})
+			provider, err := NewProvider(context.Background())
+
 			if err != nil {
 				t.Fatalf("Failed to setup provider: %v", err)
 			}
@@ -335,6 +328,7 @@ func clearOtelEnvVars() {
 	envVars := []string{
 		"OTEL_SDK_DISABLED",              // Disables the entire OTEL SDK
 		"OTEL_SERVICE_NAME",              // Service name override
+		"OTEL_SERVICE_VERSION",           // Service version override
 		"OTEL_TRACES_EXPORTER",           // Trace exporter type (otlp, console, none, etc.)
 		"OTEL_METRICS_EXPORTER",          // Metrics exporter type (otlp, prometheus, console, none, etc.)
 		"OTEL_LOGS_EXPORTER",             // Logs exporter type (otlp, console, none, etc.)


### PR DESCRIPTION
This change is to make the otel module and logger module more generic in the hope that one day these can be a shared library that can used in other projects.