### PR TITLE
Tenant Separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ export OLP_TRACES_ADDRESS=http://localhost:3201/v1/traces
 # Tenant configuration
 export TENANT_LABEL=tenant.id           # Primary tenant attribute (checked first)
 export TENANT_LABELS=tenantId,tenant_id # Fallback tenant attributes
+export TENANT_LABEL_SEPARATOR=,         # Split value into multiple tenants (empty = single tenant)
 export TENANT_HEADER=X-Scope-OrgID      # Header to add to backend requests
 export TENANT_DEFAULT=default           # Default tenant if not found
 
@@ -428,6 +429,7 @@ Available TLS options for each:
 |---------------------|---------|-------------|
 | `TENANT_LABEL` | `tenant.id` | Primary resource attribute key containing tenant ID (checked first) |
 | `TENANT_LABELS` | `""` | Comma-separated list of fallback attribute keys to check if primary is not found |
+| `TENANT_LABEL_SEPARATOR` | `""` | Separator used to split the resolved tenant value into multiple tenants. Empty (default) treats the value as a single tenant |
 | `TENANT_FORMAT` | `%s` | Format string for tenant ID (e.g., `%s-prod`) |
 | `TENANT_HEADER` | `X-Scope-OrgID` | HTTP header for tenant ID when forwarding |
 | `TENANT_DEFAULT` | `default` | Default tenant when none specified |
@@ -436,11 +438,13 @@ Available TLS options for each:
 1. First checks the dedicated label specified by `TENANT_LABEL` (e.g., `tenant.id`)
 2. If not found, checks each label in `TENANT_LABELS` in order (e.g., `tenantId`, `tenant_id`)
 3. If still not found, uses the default specified by `TENANT_DEFAULT`
+4. If `TENANT_LABEL_SEPARATOR` is set, the resolved value is split into multiple tenants
 
 **Example Configuration:**
 ```bash
 export TENANT_LABEL=tenant.id                    # Primary tenant attribute (checked first)
 export TENANT_LABELS=tenantId,tenant_id,org.id   # Fallback attributes (checked in order)
+export TENANT_LABEL_SEPARATOR=,                  # Split the resolved value into multiple tenants
 export TENANT_DEFAULT=default                     # Used if no tenant attribute found
 ```
 
@@ -499,6 +503,36 @@ TENANT_DEFAULT=shared
 # Scenario 4: Resource has no tenant attributes
 # → Uses "shared" (TENANT_DEFAULT)
 ```
+
+### Multi-Tenant Fan-Out
+
+By default the resolved tenant value is treated as a single tenant. Setting `TENANT_LABEL_SEPARATOR` splits it, so one resource can be forwarded to several tenants — one request per tenant, each with its own `TENANT_HEADER` value.
+
+```bash
+TENANT_LABEL=tenant.id
+TENANT_LABEL_SEPARATOR=,
+```
+
+```protobuf
+Resource {
+  attributes: [
+    {
+      key: "tenant.id"
+      value: "team-a,team-b"   // Forwarded to both team-a and team-b
+    }
+  ]
+}
+```
+
+Splitting applies to whichever value resolution produced, including one found via `TENANT_LABELS` or supplied by `TENANT_DEFAULT`. When handling the split segments the proxy:
+
+- **Trims surrounding whitespace**, so `"team-a, team-b"` resolves to `team-a` and `team-b` rather than `team-a` and `" team-b"`
+- **Skips blank segments**, so `"team-a,,team-b"` yields two tenants, not three
+- **Deduplicates**, so `"team-a,team-a"` is sent to `team-a` once rather than duplicating the records
+
+The original attribute value is left untouched on the forwarded payload. A resource sent to `team-a` still carries `tenant.id="team-a,team-b"`, which makes it clear the data was deliberately shared with several tenants rather than misrouted.
+
+Note that fan-out multiplies outbound requests: a value naming three tenants produces three requests per signal, and `otel_lgtm_proxy_records_total` counts each record once per tenant it is forwarded to.
 
 ### Partitioning Functions
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,6 +93,9 @@ services:
       - OTEL_METRICS_EXPORTER=otlp
       - OTEL_TRACES_EXPORTER=otlp
       - OTEL_LOGS_EXPORTER=otlp
+      # Split a resolved tenant value on "," so one resource can fan out to
+      # several tenants. See the gen-shared-* services below.
+      - TENANT_LABEL_SEPARATOR=,
       # Note: No tenant.id set here to test default tenant logic
     depends_on:
       otel-collector:
@@ -387,6 +390,64 @@ services:
       - --otlp-insecure
       - '--otlp-attributes=tenant.id="tenant-b"'
       - --service=backend-api
+      - --duration=Inf
+      - --rate=2
+    restart: unless-stopped
+    depends_on:
+      otel-collector:
+        condition: service_healthy
+
+  # ── shared / platform-service ────────────────────────────────────────────────
+  # Exercises TENANT_LABEL_SEPARATOR: a single resource carries both tenants in
+  # one attribute, so the proxy fans it out to tenant-a and tenant-b. The value
+  # is deliberately written with a space after the comma to confirm segments are
+  # trimmed. In Grafana this service appears under both the Tenant A and Tenant B
+  # datasources, while the forwarded payload keeps the original "tenant-a, tenant-b"
+  # attribute so the sharing is visible rather than looking like a misroute.
+  gen-shared-platform-service-traces:
+    build:
+      context: ./test
+      dockerfile: Dockerfile.telemetrygen
+    command:
+      - traces
+      - --otlp-endpoint=otel-collector:4317
+      - --otlp-insecure
+      - '--otlp-attributes=tenant.id="tenant-a, tenant-b"'
+      - --service=platform-service
+      - --duration=Inf
+      - --rate=4
+    restart: unless-stopped
+    depends_on:
+      otel-collector:
+        condition: service_healthy
+
+  gen-shared-platform-service-logs:
+    build:
+      context: ./test
+      dockerfile: Dockerfile.telemetrygen
+    command:
+      - logs
+      - --otlp-endpoint=otel-collector:4317
+      - --otlp-insecure
+      - '--otlp-attributes=tenant.id="tenant-a, tenant-b"'
+      - --service=platform-service
+      - --duration=Inf
+      - --rate=6
+    restart: unless-stopped
+    depends_on:
+      otel-collector:
+        condition: service_healthy
+
+  gen-shared-platform-service-metrics:
+    build:
+      context: ./test
+      dockerfile: Dockerfile.telemetrygen
+    command:
+      - metrics
+      - --otlp-endpoint=otel-collector:4317
+      - --otlp-insecure
+      - '--otlp-attributes=tenant.id="tenant-a, tenant-b"'
+      - --service=platform-service
       - --duration=Inf
       - --rate=2
     restart: unless-stopped

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,11 +45,12 @@ type TLSConfig struct {
 
 // Tenant represents the configuration for a tenant.
 type Tenant struct {
-	Label   string   `env:"LABEL"   envDefault:"tenant.id"`
-	Labels  []string `env:"LABELS"  envDefault:""`
-	Format  string   `env:"FORMAT"  envDefault:"%s"`
-	Header  string   `env:"HEADER"  envDefault:"X-Scope-OrgID"`
-	Default string   `env:"DEFAULT" envDefault:"default"`
+	Label          string   `env:"LABEL"           envDefault:"tenant.id"`
+	Labels         []string `env:"LABELS"          envDefault:""`
+	LabelSeparator string   `env:"LABEL_SEPARATOR" envDefault:""`
+	Format         string   `env:"FORMAT"          envDefault:"%s"`
+	Header         string   `env:"HEADER"          envDefault:"X-Scope-OrgID"`
+	Default        string   `env:"DEFAULT"         envDefault:"default"`
 }
 
 // Parse parses the configuration from environment variables

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -26,6 +26,9 @@ func TestParse_Defaults(t *testing.T) {
 	if len(cfg.Tenant.Labels) != 0 {
 		t.Errorf("Tenant.Labels = %v, want empty slice", cfg.Tenant.Labels)
 	}
+	if cfg.Tenant.LabelSeparator != "" {
+		t.Errorf("Tenant.LabelSeparator = %v, want empty string", cfg.Tenant.LabelSeparator)
+	}
 	if cfg.Tenant.Format != "%s" {
 		t.Errorf("Tenant.Format = %v, want %%s", cfg.Tenant.Format)
 	}
@@ -73,6 +76,7 @@ func TestParse_AllValues(t *testing.T) {
 
 	t.Setenv("TENANT_LABEL", "app.tenant")
 	t.Setenv("TENANT_LABELS", "tenantId,namespace,org.id")
+	t.Setenv("TENANT_LABEL_SEPARATOR", ",")
 	t.Setenv("TENANT_FORMAT", "%s-staging")
 	t.Setenv("TENANT_HEADER", "X-Tenant")
 	t.Setenv("TENANT_DEFAULT", "public")
@@ -144,6 +148,9 @@ func TestParse_AllValues(t *testing.T) {
 		if cfg.Tenant.Labels[i] != label {
 			t.Errorf("Tenant.Labels[%d] = %v, want %v", i, cfg.Tenant.Labels[i], label)
 		}
+	}
+	if cfg.Tenant.LabelSeparator != "," {
+		t.Errorf("Tenant.LabelSeparator = %v, want ,", cfg.Tenant.LabelSeparator)
 	}
 	if cfg.Tenant.Format != "%s-staging" {
 		t.Errorf("Tenant.Format = %v, want %%s-staging", cfg.Tenant.Format)

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"slices"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/matt-gp/core/logger"
@@ -140,7 +141,24 @@ func (p *Processor[T]) Partition(ctx context.Context, resources []T) map[string]
 			continue
 		}
 
-		tenantMap[tenant] = append(tenantMap[tenant], resourceData)
+		// If a label separator is configured, split the tenant string and add the
+		// resource to each tenant in the map. Segments are trimmed, and blank or
+		// repeated segments are skipped so a resource is never sent to the same
+		// tenant twice.
+		if sep := p.config.Tenant.LabelSeparator; sep != "" {
+			seen := make(map[string]bool)
+			for t := range strings.SplitSeq(tenant, sep) {
+				t = strings.TrimSpace(t)
+				if t == "" || seen[t] {
+					continue
+				}
+
+				seen[t] = true
+				tenantMap[t] = append(tenantMap[t], resourceData)
+			}
+		} else {
+			tenantMap[tenant] = append(tenantMap[tenant], resourceData)
+		}
 	}
 
 	return tenantMap

--- a/internal/processor/processor_test.go
+++ b/internal/processor/processor_test.go
@@ -478,6 +478,220 @@ func TestPartition(t *testing.T) {
 				"shared": 2,
 			},
 		},
+		{
+			name: "no separator configured treats tenant as a single value",
+			resources: []*logpb.ResourceLogs{
+				{
+					Resource: &resourcepb.Resource{
+						Attributes: []*commonpb.KeyValue{
+							{Key: "tenant.id", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "tenant-a|tenant-b"}}},
+						},
+					},
+				},
+			},
+			config: &config.Config{
+				Tenant: config.Tenant{
+					Label:          "tenant.id",
+					LabelSeparator: "",
+					Default:        "default",
+				},
+			},
+			expectedTenants: map[string]int{
+				"tenant-a|tenant-b": 1,
+			},
+		},
+		{
+			name: "separator fans a resource out to each tenant",
+			resources: []*logpb.ResourceLogs{
+				{
+					Resource: &resourcepb.Resource{
+						Attributes: []*commonpb.KeyValue{
+							{Key: "tenant.id", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "tenant-a|tenant-b|tenant-c"}}},
+						},
+					},
+				},
+			},
+			config: &config.Config{
+				Tenant: config.Tenant{
+					Label:          "tenant.id",
+					LabelSeparator: "|",
+					Default:        "default",
+				},
+			},
+			expectedTenants: map[string]int{
+				"tenant-a": 1,
+				"tenant-b": 1,
+				"tenant-c": 1,
+			},
+		},
+		{
+			name: "separator merges fanned out resources with single tenant resources",
+			resources: []*logpb.ResourceLogs{
+				{
+					Resource: &resourcepb.Resource{
+						Attributes: []*commonpb.KeyValue{
+							{Key: "tenant.id", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "tenant-a,tenant-b"}}},
+						},
+					},
+				},
+				{
+					Resource: &resourcepb.Resource{
+						Attributes: []*commonpb.KeyValue{
+							{Key: "tenant.id", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "tenant-a"}}},
+						},
+					},
+				},
+			},
+			config: &config.Config{
+				Tenant: config.Tenant{
+					Label:          "tenant.id",
+					LabelSeparator: ",",
+					Default:        "default",
+				},
+			},
+			expectedTenants: map[string]int{
+				"tenant-a": 2,
+				"tenant-b": 1,
+			},
+		},
+		{
+			name: "separator trims whitespace around tenants",
+			resources: []*logpb.ResourceLogs{
+				{
+					Resource: &resourcepb.Resource{
+						Attributes: []*commonpb.KeyValue{
+							{Key: "tenant.id", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: " tenant-a , tenant-b "}}},
+						},
+					},
+				},
+			},
+			config: &config.Config{
+				Tenant: config.Tenant{
+					Label:          "tenant.id",
+					LabelSeparator: ",",
+					Default:        "default",
+				},
+			},
+			expectedTenants: map[string]int{
+				"tenant-a": 1,
+				"tenant-b": 1,
+			},
+		},
+		{
+			name: "separator skips blank and whitespace only segments",
+			resources: []*logpb.ResourceLogs{
+				{
+					Resource: &resourcepb.Resource{
+						Attributes: []*commonpb.KeyValue{
+							{Key: "tenant.id", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "tenant-a,,   ,tenant-b,"}}},
+						},
+					},
+				},
+			},
+			config: &config.Config{
+				Tenant: config.Tenant{
+					Label:          "tenant.id",
+					LabelSeparator: ",",
+					Default:        "default",
+				},
+			},
+			expectedTenants: map[string]int{
+				"tenant-a": 1,
+				"tenant-b": 1,
+			},
+		},
+		{
+			name: "separator deduplicates repeated tenants within one resource",
+			resources: []*logpb.ResourceLogs{
+				{
+					Resource: &resourcepb.Resource{
+						Attributes: []*commonpb.KeyValue{
+							{Key: "tenant.id", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "tenant-a,tenant-a, tenant-a ,tenant-b"}}},
+						},
+					},
+				},
+			},
+			config: &config.Config{
+				Tenant: config.Tenant{
+					Label:          "tenant.id",
+					LabelSeparator: ",",
+					Default:        "default",
+				},
+			},
+			expectedTenants: map[string]int{
+				"tenant-a": 1,
+				"tenant-b": 1,
+			},
+		},
+		{
+			name: "separator applies to tenants found via fallback labels",
+			resources: []*logpb.ResourceLogs{
+				{
+					Resource: &resourcepb.Resource{
+						Attributes: []*commonpb.KeyValue{
+							{Key: "tenantId", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "tenant-a,tenant-b"}}},
+						},
+					},
+				},
+			},
+			config: &config.Config{
+				Tenant: config.Tenant{
+					Label:          "tenant.id",
+					Labels:         []string{"tenantId"},
+					LabelSeparator: ",",
+					Default:        "default",
+				},
+			},
+			expectedTenants: map[string]int{
+				"tenant-a": 1,
+				"tenant-b": 1,
+			},
+		},
+		{
+			name: "separator leaves a single tenant untouched",
+			resources: []*logpb.ResourceLogs{
+				{
+					Resource: &resourcepb.Resource{
+						Attributes: []*commonpb.KeyValue{
+							{Key: "tenant.id", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "tenant-a"}}},
+						},
+					},
+				},
+			},
+			config: &config.Config{
+				Tenant: config.Tenant{
+					Label:          "tenant.id",
+					LabelSeparator: ",",
+					Default:        "default",
+				},
+			},
+			expectedTenants: map[string]int{
+				"tenant-a": 1,
+			},
+		},
+		{
+			name: "separator applies to the default tenant",
+			resources: []*logpb.ResourceLogs{
+				{
+					Resource: &resourcepb.Resource{
+						Attributes: []*commonpb.KeyValue{
+							{Key: "service.name", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "service-1"}}},
+						},
+					},
+				},
+			},
+			config: &config.Config{
+				Tenant: config.Tenant{
+					Label:          "tenant.id",
+					LabelSeparator: ",",
+					Default:        "shared-a,shared-b",
+				},
+			},
+			expectedTenants: map[string]int{
+				"shared-a": 1,
+				"shared-b": 1,
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This change adds functionality which enables sending data to multiple tenants. Use case being you may want to send logs/metrics/traces to an "all" tenant as well as the individual team.